### PR TITLE
Marie Curie is overleden aan 'beenmergdepressie'

### DIFF
--- a/afdruk/jaarwerk_marie_curie.lyx
+++ b/afdruk/jaarwerk_marie_curie.lyx
@@ -1341,7 +1341,7 @@ Radiuminstituut
  opgericht aan de Universiteit van Parijs, waar Curie directeur van werd.
  Een tweede Radiuminstituut richtte Curie in 1932 in Warschau op.
  Ze bleef directeur van het Radiuminstituut tot haar dood.
- Ze overleed in 1934 aan leukemie door een teveel aan straling.
+ Ze overleed in 1934 aan beenmergdepressie en leukemie door een teveel aan straling.
  Dit zal waarschijnlijk ook de dood van Pierre hebben veroorzaakt.
  Ze werd naast haar man in Sceaux
 \begin_inset Index idx
@@ -1557,7 +1557,7 @@ Frederic Joliot
 \end_layout
 
 \begin_layout Itemize
-1934 : Marie overlijdt aan de gevolgen van leukemie.
+1934 : Marie overlijdt aan de gevolgen van beenmergdepressie en leukemie.
  Waarschijnlijk had het werken met straling een effect op Marie' s gezondheid.
 \end_layout
 

--- a/afdruk/jaarwerk_marie_curie.tex
+++ b/afdruk/jaarwerk_marie_curie.tex
@@ -560,7 +560,7 @@ Staten om geld bij elkaar te sprokkelen voor dat instituut.
 \item Tijdens W.O. I runt ze samen met haar dochter Irene een mobiele röntgenfotodienst\index{mobiele röntgenfotodienst}.
 \item 1926 : Irene Curie huwt met de assistent van Marie Curie : Frederic
 Joliot\index{Frederic Joliot}.
-\item 1934 : Marie overlijdt aan de gevolgen van leukemie. Waarschijnlijk
+\item 1934 : Marie overlijdt aan de gevolgen van beenmergdepressie en leukemie. Waarschijnlijk
 had het werken met straling een effect op Marie' s gezondheid.
 \item 1995 : overgebracht naar het Panthèon\index{Panthèon}.
 \end{itemize}


### PR DESCRIPTION
Marie Curie is overleden aan beenmergdepressie, die op zijn beurt leukemie heeft veroorzaakt, dus heb ik dit erbij vermeld